### PR TITLE
Fixed links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Name
 
-damegender is a gender detection tool from the name coded by David Arroyo MEnéndez (DAME)
+Damegender is a gender detection tool from the name coded by David Arroyo MEnéndez (DAME)
 
 
 
@@ -50,9 +50,9 @@ DAMe Gender is for you!
     $ cd lib/python3.5/site-packages/damegender
     $ python3 main.py David
 
-To install apis extra dependencies:
+To install APIs extra dependencies:
 
-    $ pip3 install damegender[apis]
+    $ pip3 install damegender[APIs]
 
 To install mailing lists and repositories extra dependencies:
 
@@ -65,10 +65,10 @@ To install all possible dependencies
 ## Obtaining an api key
 
 Currently you can need an api key from:
--   <https://store.genderize.io/documentation>
--   <https://gender-api.com>
--   <https://www.nameapi.org/>
--   <https://v2.namsor.com/NamSorAPIv2/sign-in.html>
+-   [Genderize](https://store.genderize.io/documentation)
+-   [Gender API](https://gender-api.com)
+-   [NameAPI](https://www.nameapi.org/)
+-   [Namsor](https://v2.namsor.com/NamSorAPIv2/sign-in.html)
 
 You can execute:
 
@@ -86,44 +86,38 @@ To configure your api key
 
 ## 2021
 
--   Jornadas Online "Género y Ciencia de Datos en Deporte y Salud"
-    (UOC, 2021) <https://www.youtube.com/watch?v=hBDOf5qlcek&t=8903s>
+-   [Jornadas Online "Género y Ciencia de Datos en Deporte y Salud"
+    (UOC, 2021)](https://www.youtube.com/watch?v=hBDOf5qlcek&t=8903s)
 
--   VI Congreso Internacional de Jóvenes Investigadores con Perspectiva
-    de Género (Mesa 17 Tecnología y Género) (UC3M, 2021)
-    <https://eventos.uc3m.es/65927/programme/vi-congreso-internacional-de-jovenes-investigadorxs-con-perspectiva-de-genero.html>
+-   [VI Congreso Internacional de Jóvenes Investigadores con Perspectiva
+    de Género (Mesa 17 Tecnología y Género) (UC3M, 2021)](https://eventos.uc3m.es/65927/programme/vi-congreso-internacional-de-jovenes-investigadorxs-con-perspectiva-de-genero.html)
 
--   Tecnologías I+D+I para la Igualdad (Mesas de Comunicaciones) (UC3M, 2021)
-    <https://eventos.uc3m.es/63471/programme/tecnologias-idi-para-la-igualdad-soluciones-perspectivas-y-retos.html>
+-   [Tecnologías I+D+I para la Igualdad (Mesas de Comunicaciones) (UC3M, 2021)](https://eventos.uc3m.es/63471/programme/tecnologias-idi-para-la-igualdad-soluciones-perspectivas-y-retos.html)
 
 
 ## 2020
 
--   Seminar Series on Advanced Techniques & Tools for Software
-    Evolution. (Eindhoven University of Technology, 2020) <http://sattose.org/2020>
+-   [Seminar Series on Advanced Techniques & Tools for Software
+    Evolution. (Eindhoven University of Technology, 2020)](http://sattose.org/2020)
 
--   EsLibre (URJC, 2020) (<https://propuestas.eslib.re/2020/charlas/damegender>)
+-   [EsLibre (URJC, 2020)](https://propuestas.eslib.re/2020/charlas/damegender)
 
 
 ## 2019
 
--   Fifth Madrilenian Seminar on Software Research (URJC, 2019)
-    (<https://gregoriorobles.github.io/MadSESE/201906.html>)
+-   [Fifth Madrilenian Seminar on Software Research (URJC, 2019)](https://gregoriorobles.github.io/MadSESE/201906.html)
 
--   Procesamiento de Lenguaje Natural con Python NLTK, Damegender como
-    caso de uso. (Medialab Madrid, 2019)
-    (<https://www.medialab-matadero.es/actividades/procesamiento-de-lenguaje-natural-con-python-nltk>)
+-   [Procesamiento de Lenguaje Natural con Python NLTK, Damegender como
+    caso de uso. (Medialab Madrid, 2019)](https://www.medialab-matadero.es/actividades/procesamiento-de-lenguaje-natural-con-python-nltk)
 
--   Software Freedom Day (URJC, 2019)
-    (<https://tv.urjc.es/video/5d895319d68b148f7a8c0da6>)
+-   [Software Freedom Day (URJC, 2019)](https://tv.urjc.es/video/5d895319d68b148f7a8c0da6)
 
--   Open South Code (Málaga, 2019)
-    (<https://www.opensouthcode.org/conferences/opensouthcode2019/program/proposals/183>)
+-   [Open South Code (Málaga, 2019)](https://www.opensouthcode.org/conferences/opensouthcode2019/program/proposals/183)
 
 -   Group Retreat 2019 Workshop (URJC, 2019)
 
--   PyBCN - Damegender: gender detection with NLTK and Scikit
-    (Barcelona, 2019) (<https://www.youtube.com/watch?v=dvN0lMgQ9Pc>)
+-   [PyBCN - Damegender: gender detection with NLTK and Scikit
+    (Barcelona, 2019)](https://www.youtube.com/watch?v=dvN0lMgQ9Pc)
 
 # Beautiful Snakes
 


### PR DESCRIPTION
Fixed all the links in README.md which looked cluttered. API is the standard and it shouldn't be spelled like 'api' or 'Api'. @davidam Please review.