### PR TITLE
Fix link to Genderize.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ To install all possible dependencies
 ## Obtaining an api key
 
 Currently you can need an api key from:
--   [Genderize](https://store.genderize.io/)
+-   [Genderize](https://genderize.io/)
 -   [Gender API](https://gender-api.com)
 -   [NameAPI](https://www.nameapi.org/)
 -   [Namsor](https://namsor.app/api-documentation)


### PR DESCRIPTION
Hi David

I moved the store domain to the main domain, so the link currently goes through a redirect.
Just hoping to clear it up in the README :) 

Alternatively it could link to https://genderize.io/pricing since it's linked in the context of obtaining an API key.